### PR TITLE
Consistent handling of the number of OpenMP threads

### DIFF
--- a/R/README.md
+++ b/R/README.md
@@ -10,7 +10,7 @@ Before you use the R interface, you must build ThunderSVM.
 ## Methods
 By default, the directory for storing the training data and results is the working directory.
 
-*svm_train_R(svm_type = 0, kernel = 2,degree = 3,gamma = 'auto',  coef0 = 0.0, nu = 0.5, cost = 1.0, epsilon = 0.1, tol = 0.001, probability = FALSE, class_weight = 'None', cv = -1, verbose = FALSE, max_iter = -1, dataset = 'None', model_file = 'None')*
+*svm_train_R(svm_type = 0, kernel = 2,degree = 3,gamma = 'auto',  coef0 = 0.0, nu = 0.5, cost = 1.0, epsilon = 0.1, tol = 0.001, probability = FALSE, class_weight = 'None', cv = -1, verbose = FALSE, max_iter = -1, n_cores = -1, dataset = 'None', model_file = 'None')*
 
 *svm_predict_R(test_dataset = 'None', model_file = 'None', out_file = 'None')*
 
@@ -80,6 +80,9 @@ svm_predict_R(test_dataset = "../dataset/test_dataset.txt", model_file = "../dat
 
 *max_iter*: int, optional (default=-1)\
     hard limit on the number of iterations within the solver, or -1 for no limit.
+
+*n_cores*: int, optional (default=-1)\
+    set the number of cpu cores to use, -1 for maximum
 
 *dataset*: string\
     file path to training dataset.

--- a/src/thundersvm/cmdparser.cpp
+++ b/src/thundersvm/cmdparser.cpp
@@ -150,12 +150,10 @@ void CMDParser::parse_command_line(int argc, char **argv) {
                     HelpInfo_svmtrain();
             }
         }
-        if (n_cores == -1) {
-            omp_set_num_threads(omp_get_max_threads());
-        } else if (n_cores <= 0) {
-            LOG(ERROR) << "cores number must bigger than 0";
-        } else {
+        if (n_cores > 0) {
             omp_set_num_threads(n_cores);
+        } else if (n_cores != -1) {
+            LOG(ERROR) << "the number of cpu cores must be positive or -1";
         }
         if (i >= argc)
             HelpInfo_svmtrain();
@@ -281,12 +279,10 @@ void CMDParser::parse_python(int argc, char **argv) {
                 HelpInfo_svmtrain();
         }
     }
-    if (n_cores == -1) {
-        omp_set_num_threads(omp_get_num_procs());
-    } else if (n_cores <= 0) {
-        LOG(ERROR) << "cores number must bigger than 0";
-    } else {
+    if (n_cores > 0) {
         omp_set_num_threads(n_cores);
+    } else if (n_cores != -1) {
+        LOG(ERROR) << "the number of cpu cores must be positive or -1";
     }
     if (i > argc)
         HelpInfo_svmtrain();

--- a/src/thundersvm/svm_R_interface.cpp
+++ b/src/thundersvm/svm_R_interface.cpp
@@ -143,15 +143,13 @@ extern "C" {
             el::Loggers::reconfigureAllLoggers(el::ConfigurationType::Enabled, "false");
         else
             el::Loggers::reconfigureAllLoggers(el::ConfigurationType::Enabled, "true");
-        if(n_cores[0] == -1){
-            omp_set_num_threads(omp_get_num_procs());
-        }
-        else if(n_cores[0] <= 0){
-            LOG(ERROR) << "cores number must bigger than 0";
-        }
-        else{
+
+        if (n_cores[0] > 0) {
             omp_set_num_threads(n_cores[0]);
+        } else if (n_cores[0] != -1) {
+            LOG(ERROR) << "n_cores must be positive or -1";
         }
+
         char input_file_path[1024] = DATASET_DIR;
         char model_file_path[1024] = DATASET_DIR;
         strcat(input_file_path, "../R/");

--- a/src/thundersvm/thundersvm-scikit.cpp
+++ b/src/thundersvm/thundersvm-scikit.cpp
@@ -162,12 +162,13 @@ extern "C" {
             el::Loggers::reconfigureAllLoggers(el::ConfigurationType::Enabled, "true");
         else
             el::Loggers::reconfigureAllLoggers(el::ConfigurationType::Enabled, "false");
-        if((n_cores <= 0) && (n_cores != -1)){
-            LOG(ERROR) << "cores number must bigger than 0";
-            succeed[0] = -1;
-        }
-        else
+
+        if (n_cores > 0) {
             omp_set_num_threads(n_cores);
+        } else if (n_cores != -1) {
+            LOG(ERROR) << "n_jobs must be positive or -1";
+        }
+
         DataSet train_dataset;
         train_dataset.load_from_dense(row_size, features, data, label);
 //        SvmModel* model;

--- a/src/thundersvm/thundersvm-scikit.cpp
+++ b/src/thundersvm/thundersvm-scikit.cpp
@@ -54,14 +54,11 @@ extern "C" {
             el::Loggers::reconfigureAllLoggers(el::ConfigurationType::Enabled, "true");
         else
             el::Loggers::reconfigureAllLoggers(el::ConfigurationType::Enabled, "false");
-        if(n_cores == -1){
-            omp_set_num_threads(omp_get_num_procs());
-        }
-        else if(n_cores <= 0){
-            LOG(ERROR) << "cores number must bigger than 0";
-        }
-        else{
+
+        if (n_cores > 0) {
             omp_set_num_threads(n_cores);
+        } else if (n_cores != -1) {
+            LOG(ERROR) << "n_jobs must be positive or -1";
         }
 
         DataSet train_dataset;


### PR DESCRIPTION
The following set of patches fixes processing of `n_jobs` in the scikit-learn wrapper and provides consistent handling of the number of OpenMP threads throughout the Python, R, and command line interfaces.

1. Calling the scikit-learn wrapper with the default argument of `n_jobs = -1` previously lead to single-threaded training on _dense_ arrays. The expected behaviour would have been to use the maximum available number of threads instead. The issue stemmed from the fact that the value `-1` was passed straight to omp_set_num_threads(), which set the number of threads to one.
2. Unified handling of `n_jobs` / `n_cores` / `cores` has the following aspects in mind besides pure consistency:
    - Allowing to control the number of threads via the `OMP_NUM_THREADS` environmental variable. This is achieved through removal of the following line, which until now always set the number of threads to the number of processors, ignoring the environment:

        ```cpp
        omp_set_num_threads(omp_get_num_procs());
        ```
    - Omission of redundant calls, which set the number of threads to the already active default:

        ```cpp
       omp_set_num_threads(omp_get_max_threads());
        ```
    - And tailoring error messages to the actual argument names for each interface in order to make them more clear.

All three interfaces have been tested and work properly. Please let me know if any changes to these patches are required. I am more than willing to adapt them to your requirements.