### PR TITLE
WIP Python performance

### DIFF
--- a/python/thundersvm/thundersvm.py
+++ b/python/thundersvm/thundersvm.py
@@ -403,7 +403,6 @@ class SvmModel(ThundersvmBase):
         thundersvm.sparse_decision(
             X.shape[0], data, indptr, indices,
             c_void_p(self.model), dec_size, dec_value_ptr)
-        self.dec_values = np.array([dec_value_ptr[index] for index in range(0, dec_size)])
         self.dec_values = np.frombuffer(dec_value_ptr, dtype=np.float32)\
             .reshape((X.shape[0], self.n_binary_model))
         return self.dec_values
@@ -430,7 +429,7 @@ class SvmModel(ThundersvmBase):
         self.n_classes = n_classes[0]
         n_support_ = (c_int * self.n_classes)()
         thundersvm.get_support_classes(n_support_, self.n_classes, c_void_p(self.model))
-        self.n_support_ = np.frombuffer(n_support_).astype(int)
+        self.n_support_ = np.frombuffer(n_support_, dtype=np.int32).astype(int)
         self.n_sv = thundersvm.n_sv(c_void_p(self.model))
 
         n_feature = (c_int * 1)()

--- a/python/thundersvm/thundersvm.py
+++ b/python/thundersvm/thundersvm.py
@@ -95,7 +95,7 @@ class SvmModel(ThundersvmBase):
         sparse = sp.isspmatrix(X)
         self._sparse = sparse and not callable(self.kernel)
         X, y = check_X_y(X, y, dtype=np.float64, order='C', accept_sparse='csr')
-        y = self.column_or_1d(y, warn=True).astype(np.float64)
+        y = column_or_1d(y, warn=True).astype(np.float64)
 
         solver_type = SVM_TYPE.index(self._impl)
 

--- a/python/thundersvm/thundersvm.py
+++ b/python/thundersvm/thundersvm.py
@@ -442,8 +442,8 @@ class SvmModel(ThundersvmBase):
         sv_indices = (c_int * self.n_sv)()
         thundersvm.get_sv(csr_row, csr_col, csr_data, data_size, sv_indices, c_void_p(self.model))
         self.row = np.frombuffer(csr_row, dtype=np.int32)
-        self.col = np.frombuffer(csr_col, dtype=np.int32)
-        self.data = np.frombuffer(csr_data, dtype=np.float32)
+        self.col = np.frombuffer(csr_col, dtype=np.int32)[:data_size[0]]
+        self.data = np.frombuffer(csr_data, dtype=np.float32)[:data_size[0]]
         self.support_vectors_ = sp.csr_matrix((self.data, self.col, self.row))
         # if self._sparse == False:
         #     self.support_vectors_ = self.support_vectors_.toarray(order = 'C')


### PR DESCRIPTION
Under certain circumstances ThunderSVM is surprisingly slow when invoked via the Python bindings. In my current use case, I have replicated nested cross-validation procedures with relatively small data sets (that is, many calls to `fit` and `predict`). There, currently significant time seems to be spent in list comprehensions that create numpy arrays from ctypes.

A quick-fix seemed to be exchanging the list comprehensions with calls to `np.frombuffer`, which improved speed quite a bit.

I created this PR in case you're interested to include these changes into upstream.