### PR TITLE
Updated installation instructions for Mac

### DIFF
--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -44,7 +44,7 @@ brew install cmake
 # in thundersvm root directory
 mkdir build
 cd build
-cmake -DCMAKE_CXX_COMPILER=[path_to_g++] -DCMAKE_C_COMPILER=[path_to_gcc] -DUSE_CUDA=ON -DUSE_EIGEN=OFF ..
+cmake -DCMAKE_CXX_COMPILER=[path_to_g++] -DCMAKE_C_COMPILER=[path_to_gcc] -DUSE_CUDA=OFF -DUSE_EIGEN=ON ..
 make -j
 ```
 


### PR DESCRIPTION
Most Macs don't support CUDA as far as I know.

Update: it looks like High Sierra (10.13) is the last version to support it. Mojave and Catalina do not.