### PR TITLE
Updated documentation and links

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,36 +2,35 @@
 [![Build status](https://ci.appveyor.com/api/projects/status/e9yoehx7orsrsh89/branch/master?svg=true)](https://ci.appveyor.com/project/shijiashuai/thundersvm/branch/master)
 [![GitHub license](https://img.shields.io/badge/license-apache2-yellowgreen)](./LICENSE)
 [![Documentation Status](https://readthedocs.org/projects/thundersvm/badge/?version=latest)](https://thundersvm.readthedocs.org)
-[![GitHub issues](https://img.shields.io/github/issues/Xtra-Computing/thundersvm.svg)](https://github.com/zeyiwen/thundersvm/issues)
+[![GitHub issues](https://img.shields.io/github/issues/Xtra-Computing/thundersvm.svg)](https://github.com/Xtra-Computing/thundersvm/issues)
 [![PyPI version](https://badge.fury.io/py/thundersvm.svg)](https://badge.fury.io/py/thundersvm)
 
 <div align="center">
-<img src="https://github.com/zeyiwen/thundersvm/raw/master/docs/_static/logo.png" width="240" height="220" align=left/>
-<img src="https://github.com/zeyiwen/thundersvm/raw/master/docs/_static/lang-logo.png" width="250" height="200" align=left/>
-<img src="https://github.com/zeyiwen/thundersvm/raw/master/docs/_static/overall.png" width="250" height="200" align=left/>
+<img src="https://github.com/Xtra-Computing/thundersvm/raw/master/docs/_static/logo.png" width="240" height="220" align=left/>
+<img src="https://github.com/Xtra-Computing/thundersvm/raw/master/docs/_static/lang-logo.png" width="250" height="200" align=left/>
+<img src="https://github.com/Xtra-Computing/thundersvm/raw/master/docs/_static/overall.png" width="250" height="200" align=left/>
 </div>
 
 ## What's new
 - We have recently released [ThunderGBM](https://github.com/Xtra-Computing/thundergbm), a fast GBDT and Random Forest library on GPUs.
 - add scikit-learn interface, see [here](https://github.com/Xtra-Computing/thundersvm/tree/master/python)
-- pre-built binaries and DLL for Windows x64 on CPUs are [avaliable](https://ci.appveyor.com/project/shijiashuai/thundersvm/branch/master/artifacts)
 ## Overview
 The mission of ThunderSVM is to help users easily and efficiently apply SVMs to solve problems. ThunderSVM exploits GPUs and multi-core CPUs to achieve high efficiency. Key features of ThunderSVM are as follows.
 * Support all functionalities of LibSVM such as one-class SVMs, SVC, SVR and probabilistic SVMs.
 * Use same command line options as LibSVM.
-* Support [Python](python/), [R](R/) and [Matlab](Matlab/) interfaces.
+* Support [Python](python/), [R](R/), [Matlab](Matlab/) and [Ruby](https://github.com/ankane/thundersvm) interfaces.
 * Supported Operating Systems: Linux, Windows and MacOS.
 
 **Why accelerate SVMs**: A [survey](https://www.kaggle.com/amberthomas/kaggle-2017-survey-results) conducted by Kaggle in 2017 shows that 26% of the data mining and machine learning practitioners are users of SVMs.
 
-[Documentations](docs/index.md) | [Installation](docs/how-to.md#install-thundersvm) | [API Reference (doxygen)](http://Xtra-Computing.github.io/thundersvm/)
+[Documentation](docs/index.md) | [Installation](docs/get-started.md#installation) | [API Reference (doxygen)](http://Xtra-Computing.github.io/thundersvm/)
 ## Contents
 - [Getting Started](https://github.com/Xtra-Computing/thundersvm#getting-started)
 - [Working without GPUs](docs/get-started.md#working-without-gpus)
 ## Getting Started
 
 ### Prerequisites
-* cmake 2.8 or above 
+* cmake 2.8 or above
 * gcc 4.8 or above for Linux and MacOS
 * Visual C++ for Windows
 
@@ -44,14 +43,14 @@ Download the Python wheel file (For Python3 or above).
 
 * For Linux
 
-    * `pip install thundersvm` for CUDA 9.0 - linux_x86_64 
-    
+    * `pip install thundersvm` for CUDA 9.0 - linux_x86_64
+
     * [CPU - linux_x86_64](https://github.com/Xtra-Computing/thundersvm/blob/d38af58e0ceb7e5d948f3ef7d2c241ba50133ee6/python/dist/thundersvm-cpu-0.2.0-py3-none-linux_x86_64.whl)
 
 * For Windows (64bit)
-    
+
     * [CUDA 10.0 - win64](https://github.com/Xtra-Computing/thundersvm/blob/d38af58e0ceb7e5d948f3ef7d2c241ba50133ee6/python/dist/thundersvm-cu10-0.2.0-py3-none-win_amd64.whl)
-    
+
     * [CPU - win64](https://github.com/Xtra-Computing/thundersvm/blob/d38af58e0ceb7e5d948f3ef7d2c241ba50133ee6/python/dist/thundersvm-cpu-0.2.0-py3-none-win_amd64.whl)
 
 Install the Python wheel file.
@@ -98,7 +97,7 @@ If ```make -j``` doesn't work, please simply use ```make```. The number of CPU c
 You will see `Accuracy = 0.98` after successful running.
 
 ## How to cite ThunderSVM
-If you use ThunderSVM in your paper, please cite our work ([full version](https://github.com/zeyiwen/thundersvm/blob/master/thundersvm-full.pdf)).
+If you use ThunderSVM in your paper, please cite our work ([full version](https://github.com/Xtra-Computing/thundersvm/blob/master/thundersvm-full.pdf)).
 ```
 @article{wenthundersvm18,
  author = {Wen, Zeyi and Shi, Jiashuai and Li, Qinbin and He, Bingsheng and Chen, Jian},
@@ -117,7 +116,7 @@ If you use ThunderSVM in your paper, please cite our work ([full version](https:
 ## Related websites
 * [LibSVM](https://www.csie.ntu.edu.tw/~cjlin/libsvm/) | [SVM<sup>light</sup>](http://svmlight.joachims.org/) | [OHD-SVM](https://github.com/OrcusCZ/OHD-SVM) | [NVIDIA Machine Learning](http://www.nvidia.com/object/machine-learning.html) | [ThunderGBM](https://github.com/Xtra-Computing/thundergbm)
 
-## Acknowlegement 
+## Acknowledgement
 * We acknowledge NVIDIA for their hardware donations.
 * This project is hosted by NUS, collaborating with Prof. Jian Chen (South China University of Technology). Initial work of this project was done when Zeyi Wen worked at The University of Melbourne.
 * This work is partially supported by a MoE AcRF Tier 1 grant (T1 251RES1610) in Singapore.

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -13,10 +13,10 @@ If you want to use GPUs, you also need to install CUDA.
 
 ## Installation
 If you don't have GPUs, please go to [Working without GPUs](#working-without-gpus-a-name-withoutgpu-a) in later section of this page.
-#### Installation for  Linux
+#### Installation for Linux
 * Clone ThunderSVM repository
 ```bash
-git clone https://github.com/zeyiwen/thundersvm.git
+git clone https://github.com/Xtra-Computing/thundersvm.git
 ```
 
 * Build ThunderSVM
@@ -31,7 +31,7 @@ If ```make -j``` doesn't work, please use ```make``` instead.
 #### Installation for MacOS
 * Clone ThunderSVM repository
 ```bash
-git clone --recursive https://github.com/zeyiwen/thundersvm.git
+git clone --recursive https://github.com/Xtra-Computing/thundersvm.git
 ```
 You need to Install ```CMake``` and ```libomp``` for MacOS. If you don't have Homebrew, [here](https://brew.sh/) is its website.
 ```bash
@@ -58,7 +58,7 @@ make -j
 #### Installation for Windows
 * Clone ThunderSVM repository
 ```bash
-git clone https://github.com/zeyiwen/thundersvm.git
+git clone https://github.com/Xtra-Computing/thundersvm.git
 ```
 
 * Create a Visual Studio project
@@ -74,11 +74,11 @@ If you don't have GPUs, ThunderSVM can run purely on CPUs. The number of CPU cor
 
 * Clone ThunderSVM repository
 ```bash
-git clone https://github.com/zeyiwen/thundersvm.git
+git clone https://github.com/Xtra-Computing/thundersvm.git
 ```
 
-* Get Eigen Library. ThunderSVM uses [Eigen](http://eigen.tuxfamily.org/index.php?title=Main_Page) for matrix calculation. To use Eigen, just 
-initialize the submodule. 
+* Get Eigen Library. ThunderSVM uses [Eigen](http://eigen.tuxfamily.org/index.php?title=Main_Page) for matrix calculation. To use Eigen, just
+initialize the submodule.
 ```bash
 # in thundersvm root directory
 git submodule init eigen && git submodule update
@@ -105,7 +105,7 @@ cmake .. -DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=TRUE -DBUILD_SHARED_LIBS=TRUE -DUSE_
 Then, you can open the generated the Visual Studio project file to build ThunderSVM.
 
 ## Training SVMs
-We show some concrete examples of using ThunderSVM. ThunderSVM uses the same command line options as LibSVM, so existing users of LibSVM can use ThunderSVM easily. For new users of SVMs, the [Parameters](parameters.md) page provides explanation for the usage of each option. 
+We show some concrete examples of using ThunderSVM. ThunderSVM uses the same command line options as LibSVM, so existing users of LibSVM can use ThunderSVM easily. For new users of SVMs, the [Parameters](parameters.md) page provides explanation for the usage of each option.
 
 ### Training SVMs for Classification
 In the following, we provide an example of using ThunderSVM for the MNIST dataset.
@@ -136,7 +136,7 @@ The usage of other SVM algorithms (such as SVM regression) is similar to the abo
 ```bash
 ./thundersvm-train -s 3 -t 2 -g 3.8 -c 1000 abalone_scale svm.model
 ```
-The meaning of each option can be found in the [Parameters](parameters.md) page. 
+The meaning of each option can be found in the [Parameters](parameters.md) page.
 
 ### Interfaces
 ThunderSVM provides Python, R and Matlab interfaces. You can find the instructions in the corresponding subdirectories on GitHub.

--- a/docs/how-to.md
+++ b/docs/how-to.md
@@ -2,56 +2,8 @@
 This page is for key instructions of intalling, using and contributing to ThunderSVM. ThunderSVM has been used by many users, and everyone can contribute to ThunderSVM to make it better.
 
 ## Install ThunderSVM
-To use ThunderSVM, we need to install the following software:
 
-* ```cmake``` 2.8 or above
-* ```gcc``` 4.8 or above for Linux and MacOS; ```Visual C++``` for Windows
-
-If you want to use GPUs, you also need to install CUDA.
-
-* [CUDA](https://developer.nvidia.com/cuda-downloads) 7.5 or above
-
-After installing the above software, you can start compiling ThunderSVM.
-
-* Clone ThunderSVM repository
-```bash
-git clone https://github.com/zeyiwen/thundersvm.git
-```
-
-If you don't have a GPU or want to run ThunderSVM purely on CPUs, you need to add a submodule to ThunderSVM by the following command. Please refer to [Working without GPUs](http://thundersvm.readthedocs.io/en/latest/get-started.html#working-without-gpus-a-name-withoutgpu-a) for more information.
-```bash
-# in thundersvm root directory
-git submodule init eigen && git submodule update
-```
-
-* Build the executable for Linux, use the following commands.
-```bash
-cd thundersvm
-mkdir build
-cd build
-cmake ..
-make -j
-```
-If ```make -j``` doesn't work, please simply use ```make``` instead.
-
-* Build for MacOS, use the following commands (```[path_to_g++]``` and ```[path_to_gcc]``` typically look like ```/usr/local/bin/g++-7``` and ```/usr/local/bin/gcc-7```, respectively.).
-```
-# in thundersvm root directory
-mkdir build
-cd build
-cmake -DCMAKE_CXX_COMPILER=[path_to_g++] -DCMAKE_C_COMPILER=[path_to_gcc] -DUSE_CUDA=ON -DUSE_EIGEN=OFF ..
-make -j
-```
-
-* Build the executable for Windows, use the following example commands. You need to change the Visual Studio version if you are using a different version of Visual Studio.
-```bash
-mkdir build
-cd build
-cmake ..  -DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=TRUE -DBUILD_SHARED_LIBS=TRUE -G "Visual Studio 14 2015 Win64"
-```
-The above commands generate some Visual Studio project files, open the Visual Studio project in the ```build``` directory to start building ThunderSVM on Windows. Please note that CMake should be 3.4 or above for Windows.
-
-You can now use ThunderSVM, and the options of executing ThunderSVM are available [here](parameters.html). Please refer to [Getting Started](get-started.html) for some examples of training SVMs using ThunderSVM.
+Please refer to [Getting Started](get-started.html) for installation and some examples of training SVMs using ThunderSVM.
 
 ## How can I do grid search?
    Since ThunderSVM supports cross-validation, you can write a simple grid.sh script like the following one. Then run ``` sh grid.sh [dataset]```.  You may modify the script to meet your needs. Indeed, ThunderSVM supports the same command line parameters as LIBSVM. So the script grid.py in LIBSVM can be used for ThunderSVM with minor modifications.
@@ -100,7 +52,7 @@ At this point, make sure you have generated the documents of ThunderSVM. You can
 ## Contribute to ThunderSVM
 You need to fetch the latest version of ThunderSVM before submitting a pull request.
 ```bash
-git remote add upstream https://github.com/zeyiwen/thundersvm.git
+git remote add upstream https://github.com/Xtra-Computing/thundersvm.git
 git fetch upstream
 git rebase upstream/master
 ```
@@ -112,11 +64,11 @@ Please note that ```cmake .. [-D<options>=<args>]``` produces a  ```CMakeCache.t
 #### Build test on Linux
 * Clone ThunderSVM repository
 ```bash
-git clone https://github.com/zeyiwen/thundersvm.git
+git clone https://github.com/Xtra-Computing/thundersvm.git
 git submodule update --init src/test/googletest
 ```
 
-* Build the binary for testing 
+* Build the binary for testing
 ```bash
 mkdir build
 cd build
@@ -128,12 +80,12 @@ If ```make -j runtest``` doesn't work, please use ```make runtest``` instead. Ma
 #### Build test on MacOS
 * Clone ThunderSVM repository
 ```bash
-git clone https://github.com/zeyiwen/thundersvm.git
+git clone https://github.com/Xtra-Computing/thundersvm.git
 git submodule init eigen && git submodule update
 git submodule update --init src/test/googletest
 ```
 
-* Build the binary for testing 
+* Build the binary for testing
 ```bash
 mkdir build
 cd build
@@ -145,7 +97,7 @@ Where ```[path_to_g++]``` and ```[path_to_gcc]``` typically look like ```/usr/lo
 #### Build test on Windows
 * Clone ThunderSVM repository
 ```bash
-git clone https://github.com/zeyiwen/thundersvm.git
+git clone https://github.com/Xtra-Computing/thundersvm.git
 git submodule update --init src/test/googletest
 ```
 
@@ -162,7 +114,7 @@ You need to change the Visual Studio version if you are using a different versio
 You have to ensure the repository is identical to the latest one.
 * Clone ThunderSVM repository
 ```bash
-git clone https://github.com/zeyiwen/thundersvm.git
+git clone https://github.com/Xtra-Computing/thundersvm.git
 ```
 * Build the binary
 ```base

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,9 +9,9 @@ The mission of ThunderSVM is to help users easily and efficiently apply SVMs to 
 **Why accelerate SVMs**: A [survey](https://www.kaggle.com/amberthomas/kaggle-2017-survey-results) conducted by Kaggle in 2017 shows that 26% of the data mining and machine learning practitioners are users of SVMs.
 
 <div align="center">
-<img src="https://github.com/zeyiwen/thundersvm/raw/master/docs/_static/logo.png" width="220" height="180" align=left/>
-<img src="https://github.com/zeyiwen/thundersvm/raw/master/docs/_static/lang-logo.png" width="230" height="180" align=left/>
-<img src="https://github.com/zeyiwen/thundersvm/raw/master/docs/_static/overall.png" width="230" height="180" align=left/>
+<img src="https://github.com/Xtra-Computing/thundersvm/raw/master/docs/_static/logo.png" width="220" height="180" align=left/>
+<img src="https://github.com/Xtra-Computing/thundersvm/raw/master/docs/_static/lang-logo.png" width="230" height="180" align=left/>
+<img src="https://github.com/Xtra-Computing/thundersvm/raw/master/docs/_static/overall.png" width="230" height="180" align=left/>
 </div>
 
 ## More information about ThunderSVM

--- a/python/setup.py
+++ b/python/setup.py
@@ -12,7 +12,7 @@ class bdist_wheel(_bdist_wheel):
     def finalize_options(self):
         _bdist_wheel.finalize_options(self)
         self.root_is_pure = False
-            
+
 dirname = path.dirname(path.abspath(__file__))
 
 if platform == "linux" or platform == "linux2":
@@ -33,7 +33,7 @@ setuptools.setup(name="thundersvm" + os.environ['BUILD_TAG'],
                  description="A Fast SVM Library on GPUs and CPUs",
                  long_description="The mission of ThunderSVM is to help users easily and efficiently apply SVMs to solve problems. ThunderSVM exploits GPUs and multi-core CPUs to achieve high efficiency",
                  long_description_content_type="text/plain",
-                 url="https://github.com/zeyiwen/thundersvm",
+                 url="https://github.com/Xtra-Computing/thundersvm",
                  package_data={"thundersvm": [path.basename(lib_path)]},
                  setup_requires=['wheel'],
                  install_requires=['numpy', 'scipy', 'scikit-learn'],


### PR DESCRIPTION
Made a number of updates to documentation and links (mostly based on #181):

- Added link to Ruby library
- Removed reference to pre-built Windows libraries
- Removed installation instructions from `docs/how-to.md` (linked to `docs/get-started.md`)
- Switched GitHub links from `zeyiwen` to `Xtra-Computing`
- Fixed typos (Documentation, Acknowledgements)
- Removed trailing spaces

Let me know if any of these aren't desired and I'll back them out.