### PR TITLE
CMakeLists.txt: Added install target

### DIFF
--- a/cmake/thundersvmConfig.cmake.in
+++ b/cmake/thundersvmConfig.cmake.in
@@ -1,0 +1,4 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")
+check_required_components("@PROJECT_NAME@")

--- a/src/thundersvm/CMakeLists.txt
+++ b/src/thundersvm/CMakeLists.txt
@@ -27,3 +27,35 @@ endif ()
 
 target_link_libraries(${PROJECT_NAME}-train ${LINK_LIBRARY} ${PROJECT_LIB_NAME})
 target_link_libraries(${PROJECT_NAME}-predict ${LINK_LIBRARY} ${PROJECT_LIB_NAME})
+
+# Export the package for use from the build tree
+export(TARGETS ${PROJECT_NAME} NAMESPACE XComp:: FILE cmake/${PROJECT_NAME}Targets.cmake)
+export(PACKAGE ${PROJECT_NAME})
+
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file(
+    cmake/${PROJECT_NAME}ConfigVersion.cmake
+    VERSION ${PROJECT_VERSION}
+    COMPATIBILITY AnyNewerVersion)
+
+configure_package_config_file(
+    ${CMAKE_SOURCE_DIR}/cmake/${PROJECT_NAME}Config.cmake.in
+    ${CMAKE_CURRENT_BINARY_DIR}/cmake/${PROJECT_NAME}Config.cmake
+    INSTALL_DESTINATION lib/cmake/)
+
+install(TARGETS ${PROJECT_NAME}
+    EXPORT ${PROJECT_NAME}Targets
+    ARCHIVE DESTINATION lib
+    LIBRARY DESTINATION lib
+    RUNTIME DESTINATION bin
+    INCLUDES DESTINATION include)
+install(DIRECTORY ${CMAKE_SOURCE_DIR}/include/thundersvm DESTINATION include/)
+install(FILES ${CMAKE_BINARY_DIR}/config.h DESTINATION include/thundersvm/)
+
+install(FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/cmake/${PROJECT_NAME}Config.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/cmake/${PROJECT_NAME}ConfigVersion.cmake
+    DESTINATION lib/cmake/)
+
+install(EXPORT ${PROJECT_NAME}Targets
+    NAMESPACE XComp:: DESTINATION lib/cmake/)


### PR DESCRIPTION
This PR adds an install target so that thundersvm can be used from downstream projects. It also exports the cmake configuration for thundersvm.

Users can perform an installation simply with `make install` like in:
```
cmake -DCMAKE_INSTALL_PREFIX="/data/builds/" . && \
make && \
make install
```

Downstream cmake projects can find and use thundersvm with:
```
find_package(thundersvm 0.1.0 REQUIRED)
...
target_link_libraries(${PROJECT_NAME} XComp::thundersvm)
```

With the installed headers and library we can use thundersvm successfully in our project from C++. I think this can be very useful to many users already now.