### PR TITLE
Further improve install target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,7 +73,7 @@ set(COMMON_INCLUDES ${PROJECT_SOURCE_DIR}/include ${CMAKE_CURRENT_BINARY_DIR})
 
 
 set(DATASET_DIR ${PROJECT_SOURCE_DIR}/dataset/)
-configure_file(include/thundersvm/config.h.in config.h)
+configure_file(include/thundersvm/config.h.in thundersvm/config.h)
 
 set(PROJECT_LIB_NAME ${PROJECT_NAME})
 include_directories(${COMMON_INCLUDES})

--- a/include/thundersvm/clion_cuda.h
+++ b/include/thundersvm/clion_cuda.h
@@ -5,7 +5,7 @@
 #ifndef THUNDERSVM_CLION_CUDA_H
 #define THUNDERSVM_CLION_CUDA_H
 
-#include <config.h>
+#include <thundersvm/config.h>
 #ifdef __JETBRAINS_IDE__
 #ifdef USE_CUDA
 #include "math.h"

--- a/include/thundersvm/thundersvm.h
+++ b/include/thundersvm/thundersvm.h
@@ -8,7 +8,7 @@
 #include "util/log.h"
 #include <string>
 #include <vector>
-#include <config.h>
+#include <thundersvm/config.h>
 #include "math.h"
 #include "util/common.h"
 using std::string;

--- a/src/test/test_cross_validation.cpp
+++ b/src/test/test_cross_validation.cpp
@@ -2,7 +2,7 @@
 // Created by jiashuai on 17-10-13.
 //
 #include <gtest/gtest.h>
-#include <config.h>
+#include <thundersvm/config.h>
 #include <thundersvm/model/svc.h>
 #include <thundersvm/model/svr.h>
 #include <thundersvm/util/metric.h>

--- a/src/test/test_dataset.cpp
+++ b/src/test/test_dataset.cpp
@@ -3,7 +3,7 @@
 //
 #include "gtest/gtest.h"
 #include "thundersvm/dataset.h"
-#include <config.h>
+#include <thundersvm/config.h>
 TEST(SvmProblemTest, load_dataset){
     DataSet dataSet;
     dataSet.load_from_file(DATASET_DIR "test_dataset.txt");

--- a/src/test/test_svr.cpp
+++ b/src/test/test_svr.cpp
@@ -2,7 +2,7 @@
 // Created by jiashuai on 17-10-5.
 //
 #include <gtest/gtest.h>
-#include <config.h>
+#include <thundersvm/config.h>
 #include <thundersvm/model/nusvr.h>
 #include <thundersvm/util/metric.h>
 

--- a/src/thundersvm/CMakeLists.txt
+++ b/src/thundersvm/CMakeLists.txt
@@ -43,6 +43,10 @@ configure_package_config_file(
     ${CMAKE_CURRENT_BINARY_DIR}/cmake/${PROJECT_NAME}Config.cmake
     INSTALL_DESTINATION lib/cmake/)
 
+install(TARGETS ${PROJECT_NAME}-train ${PROJECT_NAME}-predict
+    RUNTIME DESTINATION bin
+    BUNDLE DESTINATION bin)
+
 install(TARGETS ${PROJECT_NAME}
     EXPORT ${PROJECT_NAME}Targets
     ARCHIVE DESTINATION lib

--- a/src/thundersvm/CMakeLists.txt
+++ b/src/thundersvm/CMakeLists.txt
@@ -50,7 +50,7 @@ install(TARGETS ${PROJECT_NAME}
     RUNTIME DESTINATION bin
     INCLUDES DESTINATION include)
 install(DIRECTORY ${CMAKE_SOURCE_DIR}/include/thundersvm DESTINATION include/)
-install(FILES ${CMAKE_BINARY_DIR}/config.h DESTINATION include/thundersvm/)
+install(FILES ${CMAKE_BINARY_DIR}/thundersvm/config.h DESTINATION include/thundersvm/)
 
 install(FILES
     ${CMAKE_CURRENT_BINARY_DIR}/cmake/${PROJECT_NAME}Config.cmake

--- a/src/thundersvm/kernel/kernelmatrix_kernel.cu
+++ b/src/thundersvm/kernel/kernelmatrix_kernel.cu
@@ -4,7 +4,7 @@
 #include <thundersvm/syncarray.h>
 #include <cusparse.h>
 #include "thundersvm/kernel/kernelmatrix_kernel.h"
-#include <config.h>
+#include <thundersvm/config.h>
 
 namespace svm_kernel {
     __global__ void


### PR DESCRIPTION
This PR adds to improvements to the install target:
  * The header file `config.h` is now expected as `thundersvm/config.h` like all other headers. This is done already at build time, and preserved at install time.
  * Binaries are now also installed, along the library and headers.

This PR includes changes requested in #184
