### PR TITLE
Fix pickling

### DIFF
--- a/include/thundersvm/model/svmmodel.h
+++ b/include/thundersvm/model/svmmodel.h
@@ -66,6 +66,17 @@ public:
      */
     virtual void load_from_file(string path);
 
+    /**
+     * save SvmModel to a string
+     */
+    virtual string save_to_string();
+
+    /**
+     * load SvmModel from a string created by save_to_string.
+     * @param data string created by save_to_string
+     */
+    virtual void load_from_string(string data);
+
     //return n_total_sv
     int total_sv() const;
 

--- a/src/thundersvm/thundersvm-scikit.cpp
+++ b/src/thundersvm/thundersvm-scikit.cpp
@@ -354,6 +354,26 @@ extern "C" {
         model->load_from_file(path);
     }
 
+   char* save_to_string_scikit(SvmModel *model){
+        string s = model->save_to_string();
+        // Copy the bytes to the heap so we can send to Python
+        char* buf = (char *)malloc(s.length());
+        memcpy(buf, s.c_str(), s.length());
+        return buf;
+    }
+
+    /* Because we allocate the string returned by save_to_string_scikit on the
+     * heap with malloc, we provide free_string as a way of cleaning up from
+     * python code */
+    void free_string(char* s) {
+        free(s);
+    }
+
+    void load_from_string_scikit(SvmModel *model, char *mstring) {
+        string s(mstring);
+        model->load_from_string(mstring);
+    }
+
     void get_pro(SvmModel *model, float* prob){
         vector<float> prob_predict;
         prob_predict = model->get_prob_predict();


### PR DESCRIPTION
This PR addresses #110 and #157 (pickling of Python models) as follows:

- Add save_to/load_from_string methods to C++ SvmModel class.  These are basically the same as the save_to/load_from_file methods but write to a string instead of a file.  Refactor the latter functions to work through the new functions (in other words creating a string then saving it to a file) to avoid code duplication.  
- Create the corresponding  extern "C"{ } functions in thundersvm-scikit.cpp
- Add save_to/load_from_string methods to python SvmModel class
- Finally, add __getstate__ and __setstate__ functions which enable pickling.  